### PR TITLE
Use isparta instead of gulp-jsx-coverage. issue #6

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var babel = require('gulp-babel');
-var coverage = require('gulp-jsx-coverage');
 var gulp = require('gulp');
 var jshint = require('gulp-jshint');
 var mocha = require('gulp-spawn-mocha');
@@ -36,31 +35,13 @@ gulp.task('mocha', function () {
 		.pipe(mocha());
 });
 
-gulp.task('coverage', coverage.createTask({
-	src: src.concat(test),
+gulp.task('coverage', shell.task(
+	'babel-node ./node_modules/isparta/bin/isparta cover --report text --report html --report lcov ./node_modules/mocha/bin/_mocha'
+));
 
-	istanbul: {
-		coverageVariable: '__COVERAGE__',
-		exclude: /node_modules|test/,
-	},
-
-	transpile: {
-		babel: {
-			include: /\.js$/,
-			exclude: /node_modules/,
-		},
-	},
-
-	coverage: {
-		reporters: ['text-summary', 'json', 'lcov'],
-		directory: 'coverage',
-	},
-}));
-
-gulp.task('coveralls', ['coverage'], function () {
-	gulp.src('gulpfile.js', {read: false})
-		.pipe(shell('node_modules/.bin/coveralls < coverage/lcov.info'));
-});
+gulp.task('coveralls', ['coverage'], shell.task(
+	'node_modules/.bin/coveralls < coverage/lcov.info'
+));
 
 gulp.task('watch', function () {
 	gulp.watch([].concat(src, test), ['test']);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "prepublish": "gulp prepublish",
-    "test": "gulp test"
+    "test": "gulp test",
+    "coverage": "gulp coverage"
   },
   "repository": {
     "type": "git",
@@ -32,10 +33,10 @@
     "gulp": "^3.9.0",
     "gulp-babel": "^5.2.0",
     "gulp-jshint": "^1.11.2",
-    "gulp-jsx-coverage": "^0.2.2",
     "gulp-sequence": "^0.4.0",
     "gulp-shell": "^0.4.2",
     "gulp-spawn-mocha": "^2.2.1",
+    "isparta": "^3.0.3",
     "jshint-stylish": "^2.0.1",
     "mocha": "^2.2.5",
     "sinon": "^1.15.4"


### PR DESCRIPTION
[isparta](https://github.com/douglasduteil/isparta) has better ES6 source mapping.

[Coverall result](https://coveralls.io/builds/3375694/source?filename=lib%2Fansiparser.js) looks good.
